### PR TITLE
Fix non-graceful termination of FastCGI apps on Windows

### DIFF
--- a/debian/patches/byte-compile-against-apache24.diff
+++ b/debian/patches/byte-compile-against-apache24.diff
@@ -1,8 +1,8 @@
 Index: libapache-mod-fastcgi/fcgi.h
 ===================================================================
---- libapache-mod-fastcgi.orig/fcgi.h	2012-03-07 14:29:04.005720240 +0100
-+++ libapache-mod-fastcgi/fcgi.h	2012-03-07 14:29:07.830566657 +0100
-@@ -34,6 +34,10 @@
+--- libapache-mod-fastcgi.orig/fcgi.h	2008-09-22 06:36:06.000000000 -0400
++++ libapache-mod-fastcgi/fcgi.h	2013-12-01 10:17:42.480086695 -0500
+@@ -34,6 +34,14 @@
  #define APACHE2
  #endif
  
@@ -10,10 +10,14 @@ Index: libapache-mod-fastcgi/fcgi.h
 +#define APACHE24
 +#endif
 +
++#ifdef APLOG_USE_MODULE
++APLOG_USE_MODULE(fastcgi);
++#endif
++
  #ifdef APACHE2
  
  #include <sys/stat.h>
-@@ -57,10 +61,16 @@
+@@ -57,10 +65,16 @@
  #define XtOffsetOf APR_OFFSETOF
  #define ap_select select
  
@@ -30,7 +34,7 @@ Index: libapache-mod-fastcgi/fcgi.h
  
  #ifndef S_ISDIR
  #define S_ISDIR(m)      (((m)&(S_IFMT)) == (S_IFDIR))
-@@ -365,42 +375,42 @@
+@@ -354,42 +368,42 @@
  #ifdef APACHE2
  
  #ifdef WIN32
@@ -110,8 +114,8 @@ Index: libapache-mod-fastcgi/fcgi.h
  
 Index: libapache-mod-fastcgi/mod_fastcgi.c
 ===================================================================
---- libapache-mod-fastcgi.orig/mod_fastcgi.c	2012-03-07 14:29:04.017047773 +0100
-+++ libapache-mod-fastcgi/mod_fastcgi.c	2012-03-07 14:29:07.841272721 +0100
+--- libapache-mod-fastcgi.orig/mod_fastcgi.c	2008-11-09 09:31:03.000000000 -0500
++++ libapache-mod-fastcgi/mod_fastcgi.c	2013-12-01 10:16:51.472085611 -0500
 @@ -97,6 +97,10 @@
  } while (0)
  #endif
@@ -123,15 +127,3 @@ Index: libapache-mod-fastcgi/mod_fastcgi.c
  /*
   * Global variables
   */
-@@ -3014,7 +3018,11 @@
-     ap_hook_fixups(fixups, NULL, NULL, APR_HOOK_MIDDLE); 
- }
- 
-+#ifdef APACHE24
-+AP_DECLARE_MODULE(fastcgi) =
-+#else
- module AP_MODULE_DECLARE_DATA fastcgi_module =
-+#endif
- {
-     STANDARD20_MODULE_STUFF,
-     fcgi_config_create_dir_config,  /* per-directory config creator */

--- a/fcgi_pm.c
+++ b/fcgi_pm.c
@@ -201,7 +201,8 @@ static void shutdown_all()
         /* Send KILL to all processes */
         for (i = 0; i < numChildren; i++, proc++) 
         {
-            if (proc->state == FCGI_RUNNING_STATE) 
+            if (proc->state == FCGI_RUNNING_STATE
+                || proc->state == FCGI_VICTIM_STATE)
             {
                 fcgi_kill(proc, SIGKILL);
             }

--- a/mod_fastcgi.c
+++ b/mod_fastcgi.c
@@ -341,6 +341,7 @@ static apcb_t init_module(server_rec *s, pool *p)
         if (rv == APR_INCHILD)
         {
             /* child */
+            ap_close_listeners();
             fcgi_pm_main(NULL);
             exit(1);
         }


### PR DESCRIPTION
This fixes a problem found with php-cgi.exe on Windows; it wouldn't terminate when httpd was stopped.

The root cause was:
- PHP doesn't respond to the termination event set by mod_fastcgi (this is a
  feature of the FastCGI programming library provided by the mod_fastcgi folks,
  which PHP apparently does not use).
- The Windows code was broken in that it wouldn't forcibly kill after sleeping
  if it had previously tried to set the termination event, due to confusionf
  about state (modified by the patch).  Even if the child_wait thread was
  running, it wouldn't have changed the state from VICTIM.

Hmmm...  Before trying to fix it I couldn't find anything useful with a web
search but after arriving at a solution I found the same one here:

http://mailman.fastcgi.com/pipermail/fastcgi-developers/2009-October/000365.html
