### PR TITLE
Update byte-fix-cast-warning-in-fcgi_config.diff

### DIFF
--- a/debian/patches/byte-fix-cast-warning-in-fcgi_config.diff
+++ b/debian/patches/byte-fix-cast-warning-in-fcgi_config.diff
@@ -7,7 +7,7 @@ Index: libapache-mod-fastcgi/fcgi_config.c
          return ap_psprintf(cmd->temp_pool, "%s: unknown option: \"%s\"", cmd->cmd->name, compat);
  
 -    switch((int)cmd->info) {
-+    switch((long)cmd->info) {
++    switch((intptr_t)cmd->info) {
          case FCGI_AUTH_TYPE_AUTHENTICATOR:
              dir_config->authenticator = auth_server;
              dir_config->authenticator_options |= (compat) ? FCGI_COMPAT : 0;


### PR DESCRIPTION
long may not be correct either. The types guaranteed to be of the same width as a pointer is intptr_t (and uintptr_t).
